### PR TITLE
added footer to readme.rmd

### DIFF
--- a/README.Rmd
+++ b/README.Rmd
@@ -129,9 +129,11 @@ opening an issue or contacting one or more of the project maintainers.
 http://contributor-covenant.org/version/1/0/0/
 
 
+## Meta
 
+* Please [report any issues or bugs](https://github.com/ropenscilabs/robotstxt/issues).
+* License: MIT
+* Get citation information for `robotstxt` in R doing `citation(package = 'robotstxt')`
 
-
-
-
+[![rofooter](https://ropensci.org/public_images/github_footer.png)](https://ropensci.org)
 


### PR DESCRIPTION
noticed that you did fix installation instructions for the new org account, but that `README.Rmd` wasn't updated - so just added footer to your `README.Rmd` 