### PR TITLE
change travis file to cache: packages and sudo: false to speed up builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@
 
 language: r
 warnings_are_errors: true
-sudo: required
+sudo: false
+cache: packages


### PR DESCRIPTION
hey @petermeissner   - going through all ropensci repos trying to speed up Travis builds by using container based builds whenever possible 

the build https://travis-ci.org/ropenscilabs/robotstxt/builds/209083820 isn't faster than the others on the first run, but should be faster the next time since deps are cached

